### PR TITLE
Restrict github actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/igalarzab/mcp-weather/security/code-scanning/1](https://github.com/igalarzab/mcp-weather/security/code-scanning/1)

To fix the issue, we will explicitly define the `permissions` key for the `test` job. Based on the job's steps, the job only requires `contents: read` permissions to read the repository's code. This adheres to the principle of least privilege and eliminates the potential risk of inheriting overly permissive default settings.

The changes will be made within the `.github/workflows/ci.yml` file by adding a `permissions` block to the `test` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
